### PR TITLE
feat: Adds the workdir for each new component

### DIFF
--- a/templates/templates/mcp-rust/metadata/snippets/component.txt
+++ b/templates/templates/mcp-rust/metadata/snippets/component.txt
@@ -9,3 +9,4 @@ source = "target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
 
 [component.{{project-name | kebab_case}}.build]
 command = "cargo build --target wasm32-wasip1 --release"
+workdir = "{{project-name}}"


### PR DESCRIPTION
Currently without this `spin build` will fail when using the empty template